### PR TITLE
Fix DEF-005: Purchase Form Sparepart Selection with Clickable Buttons

### DIFF
--- a/src/views/menu/PurchaseAddPage.vue
+++ b/src/views/menu/PurchaseAddPage.vue
@@ -33,36 +33,61 @@
           <div v-for="(sparepart, sparepartIndex) in purchase.spareparts" :key="sparepartIndex" class="list row">
             <div class="col-11">
               <div class="row">
-                <div class="col-4">
+                <!-- CRITICAL FIX: Sparepart Name with Clickable Button Suggestions -->
+                <div class="col-4 sparepart-container">
                   <input type="text" class="form-control mt-2" v-model="sparepart.sparepartName" placeholder="Part Name"
-                    data-bs-toggle="dropdown" aria-expanded="false" @change="handleInputSearch(sparepart.sparepartName)"
-                    @keyup="handleInputSearch(sparepart.sparepartName)">
-                  <ul class="dropdown-menu">
-                    <li v-for="(item, index) in searchedSpareparts" :key="index" class="dropdown-item"
-                      @click="selectItem(sparepartIndex, sparepart, item)">
+                    @input="handleInputSearch(sparepart.sparepartName)"
+                    @keyup="handleInputSearch(sparepart.sparepartName)"
+                    :class="{ 'is-invalid': !sparepart.sparepartId && sparepart.sparepartName }">
+                  
+                  <!-- CRITICAL FIX: Button-based suggestions instead of li dropdown -->
+                  <div v-if="searchedSpareparts.length > 0" class="sparepart-dropdown">
+                    <button
+                      v-for="(item, index) in searchedSpareparts"
+                      :key="index"
+                      type="button"
+                      class="sparepart-suggestion-btn"
+                      @mousedown.prevent
+                      @click="selectItem(sparepartIndex, sparepart, item)"
+                    >
                       {{ item.sparepartName }}
-                    </li>
-                  </ul>
+                    </button>
+                  </div>
+                  
+                  <div v-if="!sparepart.sparepartId && sparepart.sparepartName" class="invalid-feedback">
+                    Please select from suggestions to link sparepart ID
+                  </div>
                 </div>
-                <div class="col-2">
+                
+                <!-- CRITICAL FIX: Part Number with Clickable Button Suggestions -->
+                <div class="col-2 sparepart-container">
                   <input type="text" class="form-control mt-2" v-model="sparepart.sparepartNumber"
-                    placeholder="Part Number" data-bs-toggle="dropdown" aria-expanded="false"
-                    @change="handleInputSearch(sparepart.sparepartNumber)"
+                    placeholder="Part Number"
+                    @input="handleInputSearch(sparepart.sparepartNumber)"
                     @keyup="handleInputSearch(sparepart.sparepartNumber)">
-                  <ul class="dropdown-menu">
-                    <li v-for="(item, index) in searchedSpareparts" :key="index" class="dropdown-item"
-                      @click="selectItem(sparepartIndex, sparepart, item)">
+                  
+                  <!-- CRITICAL FIX: Button-based suggestions -->
+                  <div v-if="searchedSpareparts.length > 0" class="sparepart-dropdown">
+                    <button
+                      v-for="(item, index) in searchedSpareparts"
+                      :key="index"
+                      type="button"
+                      class="sparepart-suggestion-btn"
+                      @mousedown.prevent
+                      @click="selectItem(sparepartIndex, sparepart, item)"
+                    >
                       {{ item.sparepartNumber }}
-                    </li>
-                  </ul>
+                    </button>
+                  </div>
                 </div>
+                
                 <div class="col-2">
                   <input type="number" class="form-control mt-2" placeholder="Quantity" v-model="sparepart.quantity"
-                    @input="selectItem(sparepartIndex, sparepart)">
+                    @input="updateCalculation(sparepartIndex, sparepart)">
                 </div>
                 <div class="col-2">
                   <input type="number" class="form-control mt-2" placeholder="Unit Price"
-                    v-model="sparepart.unitPriceBuy" @change="selectItem(sparepartIndex, sparepart)">
+                    v-model="sparepart.unitPriceBuy" @change="updateCalculation(sparepartIndex, sparepart)">
                 </div>
                 <div class="col-2">
                   <input type="number" class="form-control mt-2" placeholder="Total Price"
@@ -134,18 +159,60 @@ const handleInputSearch = (search) => {
   debounce(() => searchSparepart(search), 500, 'search-purchase-sparepart')
 }
 
+// CRITICAL FIX: Enhanced selectItem function with proper sparepartId mapping
 const selectItem = (index, purchaseData, sparepartData) => {
+  // Handle case when called without sparepartData (for quantity/price updates)
+  if (!sparepartData) {
+    updateCalculation(index, purchaseData)
+    return
+  }
+  
+  console.log('Selecting sparepart for purchase:', sparepartData)
+  console.log('Current purchase data:', purchaseData)
+  
+  // CRITICAL: Map sparepartId with comprehensive fallbacks
   const data = {
     ...purchaseData,
-    ...sparepartData
+    // CRITICAL: Set sparepartId - try multiple possible field names
+    sparepartId: sparepartData.sparepartId || sparepartData.id || sparepartData.sparepart_id,
+    sparepartName: sparepartData.sparepartName || sparepartData.sparepart_name || sparepartData.name,
+    sparepartNumber: sparepartData.sparepartNumber || sparepartData.sparepart_number || sparepartData.part_number,
+    // Use buy price for purchase, not sell price
+    unitPriceBuy: sparepartData.unitPriceBuy || sparepartData.unit_price_buy || sparepartData.purchase_price || purchaseData.unitPriceBuy || 0,
+    quantity: purchaseData.quantity || 1,
+    stock: sparepartData.stock || sparepartData.available_stock || 'available'
   }
-  data.totalPrice = data.quantity * data.unitPriceBuy
+  
+  // Calculate total price
+  data.totalPrice = (data.quantity || 0) * (data.unitPriceBuy || 0)
+  
+  console.log('Final purchase sparepart data with ID:', data.sparepartId, data)
+  
+  // CRITICAL: Validate sparepartId is properly set
+  if (!data.sparepartId) {
+    console.error('CRITICAL ERROR: sparepartId not set after selection!')
+    console.error('Original sparepartData:', sparepartData)
+    alert('Error: Could not get sparepart ID from selection. Please check the sparepart data format.')
+    return
+  }
+  
+  // Update the sparepart in the array
+  purchase.value.spareparts.splice(index, 1, data)
+  
+  console.log('Purchase sparepart selection completed successfully with sparepartId:', data.sparepartId)
+}
+
+// CRITICAL FIX: Separate function for quantity/price updates without sparepartData
+const updateCalculation = (index, sparepartData) => {
+  const data = { ...sparepartData }
+  data.totalPrice = (data.quantity || 0) * (data.unitPriceBuy || 0)
+  
   purchase.value.spareparts.splice(index, 1, data)
 }
 
 const addSparepart = () => {
   purchase.value.spareparts.push({
-    sparepartId: '',
+    sparepartId: '', // CRITICAL: Initialize as empty string, will be set on selection
     sparepartName: '',
     sparepartNumber: '',
     quantity: 0,
@@ -155,9 +222,11 @@ const addSparepart = () => {
     stock: ''
   })
 }
+
 const removeSparepart = (index) => {
   purchase.value.spareparts.splice(index, 1)
 }
+
 const doPurchase = async () => {
   if (isProcessing.value) return
   try {
@@ -175,7 +244,6 @@ const doPurchaseConfirmation = () => {
   purchase.value.spareparts = purchase.value.spareparts.filter((item) => item.quantity > 0)
   modalStore.openConfirmationModal(`to Purchase ${purchase.value.spareparts.length} Spareparts ?`, 'Purchase Spareparts Success', doPurchase)
 }
-
 </script>
 
 <style lang="scss" scoped>
@@ -238,6 +306,58 @@ $secondary-color: rgb(98, 98, 98);
 
 .button-placeholder {
   width: 20px;
+}
+
+// CRITICAL FIX: Sparepart container for dropdown positioning
+.sparepart-container {
+  position: relative;
+}
+
+// CRITICAL FIX: Proper sparepart dropdown styling
+.sparepart-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1050;
+  background: white;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  margin-top: 2px;
+}
+
+// CRITICAL FIX: Clickable sparepart suggestion buttons
+.sparepart-suggestion-btn {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  color: #212529;
+  border-bottom: 1px solid #f8f9fa;
+  
+  &:hover {
+    background-color: #e9ecef;
+    color: #16181b;
+  }
+  
+  &:focus {
+    outline: none;
+    background-color: #f8f9fa;
+  }
+  
+  &:active {
+    background-color: #dee2e6;
+  }
+  
+  &:last-child {
+    border-bottom: none;
+  }
 }
 
 .dropdown-menu {


### PR DESCRIPTION
## Problem Fixed
🚨 **HIGH PRIORITY BUG**: Inventory users could not create purchase requests because sparepart selection in the purchase form was broken, causing `sparepartId` validation failures.

## Root Cause Analysis
🔍 **Same Issue as Previously Fixed in Quotation Form:**
- Purchase form was using **old dropdown implementation** (li elements)
- `sparepartId` was not being properly set when users clicked suggestions
- Backend validation failed with: `"The spareparts.0.sparepartId field is required"`
- **Same bug that was fixed in quotation form** but not applied consistently

## Fix Applied

✅ **Implemented Consistent Button-Based Suggestions:**
```vue
<!-- OLD: Non-clickable li elements -->
<ul class="dropdown-menu">
  <li class="dropdown-item" @click="selectItem(...)">
    {{ item.sparepartName }}
  </li>
</ul>

<!-- NEW: Clickable button suggestions -->
<div class="sparepart-dropdown">
  <button type="button" class="sparepart-suggestion-btn" 
          @mousedown.prevent @click="selectItem(...)">  
    {{ item.sparepartName }}
  </button>
</div>
```

✅ **Enhanced sparepartId Mapping with Fallbacks:**
```javascript
const selectItem = (index, purchaseData, sparepartData) => {
  const data = {
    ...purchaseData,
    // CRITICAL: Multiple fallback options for sparepartId
    sparepartId: sparepartData.sparepartId || sparepartData.id || sparepartData.sparepart_id,
    sparepartName: sparepartData.sparepartName || sparepartData.sparepart_name,
    sparepartNumber: sparepartData.sparepartNumber || sparepartData.sparepart_number,
    unitPriceBuy: sparepartData.unitPriceBuy || sparepartData.purchase_price
  }
  
  // Validate sparepartId is set
  if (!data.sparepartId) {
    alert('Error: Could not get sparepart ID from selection')
    return
  }
}
```

✅ **Added Visual Validation Feedback:**
```vue
<input :class="{ 'is-invalid': !sparepart.sparepartId && sparepart.sparepartName }">
<div class="invalid-feedback">
  Please select from suggestions to link sparepart ID
</div>
```

✅ **Proper CSS Styling for Button Suggestions:**
- Positioned dropdown with `z-index: 1050`
- Hover/focus states for better UX
- Consistent styling with quotation form

## Testing Evidence
**Before Fix:**
- Inventory user `eko.p@bmj.com` could access purchase form
- Sparepart suggestions appeared but were not clickable
- Form submission failed: `"The spareparts.0.sparepartId field is required"`
- **Complete inventory purchase workflow blocked**

**Expected After Fix:**
- Sparepart suggestions are clickable buttons
- sparepartId is properly set when suggestion is selected
- Purchase request creation succeeds
- Total calculation works correctly

## Impact
- ✅ **Unblocks inventory purchase request workflow**
- ✅ **Consistent UX with quotation form** (same button-based solution)
- ✅ **Proper sparepartId validation and mapping**
- ✅ **Enhanced error handling and user feedback**

## Test Plan
1. Login as Inventory user: `eko.p@bmj.com / password`
2. Navigate to `/purchase/add`
3. Type sparepart name in search field
4. Verify clickable button suggestions appear
5. Click suggestion and verify all fields populate
6. Set quantity and verify total calculates
7. Submit purchase request successfully
8. Verify purchase appears in purchase list

## Consistency Note
This fix applies the **same successful solution** from PR #13 (quotation sparepart selection fix) to the purchase form, ensuring consistent behavior across the application.

## Related Issues
- Resolves: **DEF-005** - Purchase Form Sparepart Selection Broken
- Similar to: PR #13 - Quotation sparepart selection fix
- Blocks: Inventory team purchase request workflow
- Priority: **HIGH** - Core inventory functionality

---

**Ready for Review & Testing** 🚀